### PR TITLE
Implement errorUserInfo to make SwiftLintError conform to CustomNSError

### DIFF
--- a/SwiftLint/SourceEditorCommand.swift
+++ b/SwiftLint/SourceEditorCommand.swift
@@ -130,10 +130,24 @@ class SourceEditorCommand: NSObject, XCSourceEditorCommand {
         return connection
     }()
 
-    private enum SwiftLintError: Error {
+    private enum SwiftLintError: Error, CustomNSError, CustomStringConvertible {
         case error(String)
         case helperConnectError
         case unknownCommandIdentifier
+
+        // CustomNSError
+        var errorUserInfo: [String : Any] {
+            return [NSLocalizedDescriptionKey: description]
+        }
+
+        // CustomStringConvertible
+        var description: String {
+            switch self {
+            case .error(let message): return "error: \(message)"
+            case .helperConnectError: return "Helper Connectiont Error"
+            case .unknownCommandIdentifier: return "Unknown Command Identifier"
+            }
+        }
     }
 
     typealias ReplyHandler = (Int, String, String) throws -> Void


### PR DESCRIPTION
This causes Xcode to display the error output when executing swiftlint.
e.g.
<img width="509" alt="screenshot 2018-02-13 11 02 10" src="https://user-images.githubusercontent.com/33430/36129984-63799aa4-10ad-11e8-9eeb-9592944b34c4.png">
